### PR TITLE
Adding Joins to the base query system

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,9 @@
 const ModelHandler = require('./src/handler');
+const { HttpStatusError } = require('./src/errors');
+const { parse } = require('./src/parser');
 
 module.exports = {
-    ModelHandler
+    ModelHandler,
+    HttpStatusError,
+    parse
 };

--- a/src/handler.js
+++ b/src/handler.js
@@ -11,7 +11,7 @@ class ModelHandler {
     
     create() {
         const handle = (req, res, next) => {
-            this.model
+            return this.model
                 .create(req.body)
                 .then(respond)
                 .catch(next);
@@ -30,7 +30,7 @@ class ModelHandler {
     
     get() {
         const handle = (req, res, next) => {
-            this
+            return this
                 .findOne(Object.assign({},req.query,req.params))
                 .then(respond)
                 .catch(next);
@@ -52,7 +52,7 @@ class ModelHandler {
     
     query() {
         const handle = (req, res, next) => {
-            this
+            return this
                 .findAndCountAll(req.query)
                 .then(respond)
                 .catch(next);
@@ -78,7 +78,7 @@ class ModelHandler {
     
     remove() {
         const handle = (req, res, next) => {
-            this
+            return this
                 .findOne(req.params)
                 .then(destroy)
                 .then(respond)
@@ -104,7 +104,7 @@ class ModelHandler {
     
     update() {
         const handle = (req, res, next) => {
-            this
+            return this
                 .findOne(Object.assign({},req.query,req.params))
                 .then(updateAttributes)
                 .then(respond)

--- a/src/handler.js
+++ b/src/handler.js
@@ -8,74 +8,74 @@ class ModelHandler {
         this.model = model;
         this.defaults = defaults;
     }
-
+    
     create() {
         const handle = (req, res, next) => {
             this.model
                 .create(req.body)
                 .then(respond)
                 .catch(next);
-
+            
             function respond(row) {
                 res.status(201);
                 res.send(res.transform(row));
             }
         };
-
+        
         return [
             raw,
             handle
         ];
     }
-
+    
     get() {
         const handle = (req, res, next) => {
             this
                 .findOne(Object.assign({},req.query,req.params))
                 .then(respond)
                 .catch(next);
-
+            
             function respond(row) {
                 if (!row) {
                     throw new HttpStatusError(404, 'Not Found');
                 }
-
+                
                 res.send(res.transform(row));
             }
         };
-
+        
         return [
             raw,
             handle
         ];
     }
-
+    
     query() {
         const handle = (req, res, next) => {
             this
                 .findAndCountAll(req.query)
                 .then(respond)
                 .catch(next);
-
+            
             function respond({ rows, start, end, count }) {
                 res.set('Content-Range', `${start}-${end}/${count}`);
-
+                
                 if (count > end) {
                     res.status(206);
                 } else {
                     res.status(200);
                 }
-
+                
                 res.send(res.transform(rows));
             }
         };
-
+        
         return [
             raw,
             handle
         ];
     }
-
+    
     remove() {
         const handle = (req, res, next) => {
             this
@@ -83,25 +83,25 @@ class ModelHandler {
                 .then(destroy)
                 .then(respond)
                 .catch(next);
-
+            
             function destroy(row) {
                 if (!row) {
                     throw new HttpStatusError(404, 'Not Found');
                 }
-
+                
                 return row.destroy();
             }
-
+            
             function respond() {
                 res.sendStatus(204);
             }
         };
-
+        
         return [
             handle
         ];
     }
-
+    
     update() {
         const handle = (req, res, next) => {
             this
@@ -109,48 +109,48 @@ class ModelHandler {
                 .then(updateAttributes)
                 .then(respond)
                 .catch(next);
-
+                
             function updateAttributes(row) {
                 if (!row) {
                     throw new HttpStatusError(404, 'Not Found');
                 }
-
+                
                 return row.updateAttributes(req.body);
             }
-
+            
             function respond(row) {
                 res.send(res.transform(row));
             }
         };
-
+        
         return [
             raw,
             handle
         ];
     }
-
+    
     findOne(params, options) {
         options = _.merge(parse(params, this.model), options);
 
         return this.model.findOne(options);
     }
-
+    
     findAndCountAll(params, options) {
         let parsed = parse(params, this.model);
-
+        
         options = _(parsed)
             .defaults(this.defaults)
             .merge(options)
             .value();
-
+        
         return this.model
             .findAndCountAll(options)
             .then(extract);
-
+            
         function extract({ count, rows }) {
             const start = options.offset;
             const end = Math.min(count, (options.offset + options.limit) || count);
-
+        
             return { rows, start, end, count };
         }
     }

--- a/src/handler.js
+++ b/src/handler.js
@@ -8,74 +8,74 @@ class ModelHandler {
         this.model = model;
         this.defaults = defaults;
     }
-    
+
     create() {
         const handle = (req, res, next) => {
             this.model
                 .create(req.body)
                 .then(respond)
                 .catch(next);
-            
+
             function respond(row) {
                 res.status(201);
                 res.send(res.transform(row));
             }
         };
-        
+
         return [
             raw,
             handle
         ];
     }
-    
+
     get() {
         const handle = (req, res, next) => {
             this
-                .findOne(req.params)
+                .findOne(Object.assign({},req.query,req.params))
                 .then(respond)
                 .catch(next);
-            
+
             function respond(row) {
                 if (!row) {
                     throw new HttpStatusError(404, 'Not Found');
                 }
-                
+
                 res.send(res.transform(row));
             }
         };
-        
+
         return [
             raw,
             handle
         ];
     }
-    
+
     query() {
         const handle = (req, res, next) => {
             this
                 .findAndCountAll(req.query)
                 .then(respond)
                 .catch(next);
-            
+
             function respond({ rows, start, end, count }) {
                 res.set('Content-Range', `${start}-${end}/${count}`);
-                
+
                 if (count > end) {
                     res.status(206);
                 } else {
                     res.status(200);
                 }
-                
+
                 res.send(res.transform(rows));
             }
         };
-        
+
         return [
             raw,
             handle
         ];
     }
-    
+
     remove() {
         const handle = (req, res, next) => {
             this
@@ -83,74 +83,74 @@ class ModelHandler {
                 .then(destroy)
                 .then(respond)
                 .catch(next);
-            
+
             function destroy(row) {
                 if (!row) {
                     throw new HttpStatusError(404, 'Not Found');
                 }
-                
+
                 return row.destroy();
             }
-            
+
             function respond() {
                 res.sendStatus(204);
             }
         };
-        
+
         return [
             handle
         ];
     }
-    
+
     update() {
         const handle = (req, res, next) => {
             this
-                .findOne(req.params)
+                .findOne(Object.assign({},req.query,req.params))
                 .then(updateAttributes)
                 .then(respond)
                 .catch(next);
-                
+
             function updateAttributes(row) {
                 if (!row) {
                     throw new HttpStatusError(404, 'Not Found');
                 }
-                
+
                 return row.updateAttributes(req.body);
             }
-            
+
             function respond(row) {
                 res.send(res.transform(row));
             }
         };
-        
+
         return [
             raw,
             handle
         ];
     }
-    
+
     findOne(params, options) {
         options = _.merge(parse(params, this.model), options);
 
         return this.model.findOne(options);
     }
-    
+
     findAndCountAll(params, options) {
         let parsed = parse(params, this.model);
-        
+
         options = _(parsed)
             .defaults(this.defaults)
             .merge(options)
             .value();
-        
+
         return this.model
             .findAndCountAll(options)
             .then(extract);
-            
+
         function extract({ count, rows }) {
             const start = options.offset;
             const end = Math.min(count, (options.offset + options.limit) || count);
-        
+
             return { rows, start, end, count };
         }
     }

--- a/src/parser.js
+++ b/src/parser.js
@@ -7,21 +7,23 @@ module.exports = {
 
 function parse(params, { rawAttributes }) {
     const options = {
-        where: {}    
+        where: {}
     };
-    
+
     const keywords = [
+        'includes',
         'fields',
         'limit',
         'offset',
         'sort'
     ];
-    
+
+    options.includes = parseString(params.includes);
     options.attributes = parseString(params.fields);
     options.limit = parseInteger(params.limit);
     options.offset = parseInteger(params.offset);
     options.order = parseSort(params.sort);
-    
+
     _(params)
         .omit(keywords)
         .forOwn((value, key) => {
@@ -29,7 +31,7 @@ function parse(params, { rawAttributes }) {
                 options.where[key] = parseJson(value);
             }
         });
-    
+
     return options;
 };
 
@@ -37,7 +39,7 @@ function parseString(value) {
     if (value) {
         value = value.split(',');
     }
-    
+
     return value;
 }
 
@@ -47,26 +49,26 @@ function parseJson(value) {
     } catch (error) {
         value = parseString(value);
     }
-    
+
     return value;
 }
 
 function parseInteger(value) {
     value = parseInt(value);
-    
+
     if (_.isNaN(value)) {
         value = undefined;
     }
-    
+
     return value;
 }
 
 function parseSort(value) {
     let sort = undefined;
-        
+
     if (value) {
         const keys = parseString(value);
-        
+
         sort = _.map(keys, (key) => {
             if (key.indexOf('-') === 0) {
                 return [key.substr(1), 'DESC'];
@@ -75,6 +77,6 @@ function parseSort(value) {
             }
         });
     }
-    
+
     return sort;
 }

--- a/src/parser.js
+++ b/src/parser.js
@@ -69,7 +69,7 @@ function parseIncludes(includes) {
             basePtr[includeArr[j]] = {index: returnPtr.length - 1};
           }
           basePtr = basePtr[includeArr[j]];
-          returnPtr = returnPtr.include[basePtr[includeArr[j]]].include;
+          returnPtr = returnPtr.include[basePtr[includeArr[j]].index].include;
         }
       }
     }

--- a/src/parser.js
+++ b/src/parser.js
@@ -73,7 +73,6 @@ function parseIncludes(includes) {
         }
       }
     }
-    console.log(returnObj);
     return returnObj;
 }
 

--- a/src/parser.js
+++ b/src/parser.js
@@ -50,19 +50,20 @@ function parseIncludes(includes) {
     if (includes) {
         includes = includes.split(',');
         for(let i in includes){
-          if(includes[i].indexOf('.')){
-            includeArr = includes[i].split('.')
-            let includeObj = {};
-            let includePtr = includeObj;
-            for(let j in includeArr){
-              includePtr[includeArr[j]] = {};
-              includePtr = includePtr[includeArr[j]];
-            }
-            includes[i] = includeObj;
+          if(!includes[i].indexOf('.')){
+            continue;
           }
+          includeArr = includes[i].split('.')
+          let includeObj = {};
+          let includePtr = includeObj;
+          for(let j in includeArr){
+            includePtr[includeArr[j]] = {};
+            includePtr = includePtr[includeArr[j]];
+          }
+          includes[i] = includeObj;
         }
     }
-
+    console.log(includes);
     return includes;
 }
 

--- a/src/parser.js
+++ b/src/parser.js
@@ -62,15 +62,13 @@ function parseIncludes(includes) {
         }
         includeArr = includesArr[i].split('.')
         let basePtr = baseObj;
-        let returnPtr = returnObj.include;
+        let returnPtr = returnObj;
         for(let j in includeArr){
           if(!basePtr.hasOwnProperty(includeArr[j])){
             returnPtr.push({model:includeArr[j], include:[]});
             basePtr[includeArr[j]] = {index: returnPtr.length - 1};
           }
           basePtr = basePtr[includeArr[j]];
-          console.log(returnPtr);
-          console.log(basePtr);
           returnPtr = returnPtr[basePtr.index].include;
         }
       }

--- a/src/parser.js
+++ b/src/parser.js
@@ -27,6 +27,9 @@ function parse(params, { rawAttributes }) {
     _(params)
         .omit(keywords)
         .forOwn((value, key) => {
+            if(key.indexOf('.')){
+              key = '$' + key + '$';
+            }
             options.where[key] = parseJson(value);
         });
 

--- a/src/parser.js
+++ b/src/parser.js
@@ -17,8 +17,7 @@ function parse(params, { rawAttributes }) {
         'offset',
         'sort'
     ];
-    options.include = parseIncludes(params.includes);
-    options.require = (!params.require || parseString(params.require).toLowerCase() === 'true');
+    options.include = parseIncludes(params.includes, (!params.require || parseString(params.require).toLowerCase() === 'true'));
     options.attributes = parseString(params.fields);
     options.limit = parseInteger(params.limit);
     options.offset = parseInteger(params.offset);
@@ -46,7 +45,7 @@ function parseString(value) {
     return value;
 }
 
-function parseIncludes(includes) {
+function parseIncludes(includes, required) {
     let returnObj;
     if (includes) {
       returnObj = [];
@@ -55,7 +54,7 @@ function parseIncludes(includes) {
       for(let i in includesArr){
         if(includesArr[i].indexOf('.') === - 1){
           if(!baseObj.hasOwnProperty(includesArr[i])){
-            returnObj.push({association:includesArr[i], include:[]});
+            returnObj.push({association:includesArr[i], required: required, include:[]});
             baseObj[includesArr[i]] = {index: returnObj.length - 1};
           }
           continue;
@@ -65,7 +64,7 @@ function parseIncludes(includes) {
         let returnPtr = returnObj;
         for(let j in includeArr){
           if(!basePtr.hasOwnProperty(includeArr[j])){
-            returnPtr.push({association:includeArr[j], include:[]});
+            returnPtr.push({association:includeArr[j], required: required, include:[]});
             basePtr[includeArr[j]] = {index: returnPtr.length - 1};
           }
           basePtr = basePtr[includeArr[j]];

--- a/src/parser.js
+++ b/src/parser.js
@@ -69,8 +69,9 @@ function parseIncludes(includes) {
             basePtr[includeArr[j]] = {index: returnPtr.length - 1};
           }
           basePtr = basePtr[includeArr[j]];
+          console.log(returnPtr);
+          console.log(basePtr);
           returnPtr = returnPtr[basePtr.index].include;
-
         }
       }
     }

--- a/src/parser.js
+++ b/src/parser.js
@@ -12,12 +12,13 @@ function parse(params, { rawAttributes }) {
 
     const keywords = [
         'includes',
+        'requireIncludes',
         'fields',
         'limit',
         'offset',
         'sort'
     ];
-    options.include = parseIncludes(params.includes, (!params.require || parseString(params.require).toLowerCase() === 'true'));
+    options.include = parseIncludes(params.includes, (!params.requireIncludes || parseString(params.requireIncludes).toLowerCase() === 'true'));
     options.attributes = parseString(params.fields);
     options.limit = parseInteger(params.limit);
     options.offset = parseInteger(params.offset);

--- a/src/parser.js
+++ b/src/parser.js
@@ -18,7 +18,7 @@ function parse(params, { rawAttributes }) {
         'sort'
     ];
 
-    options.includes = parseString(params.includes);
+    options.include = parseString(params.includes);
     options.attributes = parseString(params.fields);
     options.limit = parseInteger(params.limit);
     options.offset = parseInteger(params.offset);

--- a/src/parser.js
+++ b/src/parser.js
@@ -18,7 +18,7 @@ function parse(params, { rawAttributes }) {
         'offset',
         'sort'
     ];
-    options.include = parseIncludes(params.includes, (!params.requireIncludes || parseString(params.requireIncludes).toLowerCase() === 'true'));
+    options.include = parseIncludes(params.includes, (!params.requireIncludes || params.requireIncludes === 'true'));
     options.attributes = parseString(params.fields);
     options.limit = parseInteger(params.limit);
     options.offset = parseInteger(params.offset);

--- a/src/parser.js
+++ b/src/parser.js
@@ -49,22 +49,27 @@ function parseString(value) {
 function parseIncludes(includes) {
     let returnObj;
     if (includes) {
-      returnObj = {};
+      returnObj = [];
+      let baseObj = {};
       let includesArr = includes.split(',');
       for(let i in includesArr){
         if(includesArr[i].indexOf('.') === - 1){
-          if(!includes.hasOwnProperty(includesArr[i])){
-            returnObj[includesArr[i]] = {};
+          if(!baseObj.hasOwnProperty(includesArr[i])){
+            returnObj.push({model:includesArr[i], include:[]});
+            baseObj[includesArr[i]] = {index: returnObj.length - 1};
           }
           continue;
         }
         includeArr = includesArr[i].split('.')
-        let includePtr = returnObj;
+        let basePtr = baseObj;
+        let returnPtr = returnObj.include;
         for(let j in includeArr){
-          if(!includePtr.hasOwnProperty(includeArr[j])){
-            includePtr[includeArr[j]] = {};
+          if(!basePtr.hasOwnProperty(includeArr[j])){
+            returnPtr.push({model:includeArr[j], include:[]});
+            basePtr[includeArr[j]] = {index: returnPtr.length - 1};
           }
-          includePtr = includePtr[includeArr[j]];
+          basePtr = basePtr[includeArr[j]];
+          returnPtr = returnPtr.include[basePtr[includeArr[j]]].include;
         }
       }
     }

--- a/src/parser.js
+++ b/src/parser.js
@@ -68,8 +68,9 @@ function parseIncludes(includes) {
             returnPtr.push({model:includeArr[j], include:[]});
             basePtr[includeArr[j]] = {index: returnPtr.length - 1};
           }
-          returnPtr = returnPtr.include[basePtr[includeArr[j]].index].include;
           basePtr = basePtr[includeArr[j]];
+          returnPtr = returnPtr[basePtr.index].include;
+
         }
       }
     }

--- a/src/parser.js
+++ b/src/parser.js
@@ -19,6 +19,7 @@ function parse(params, { rawAttributes }) {
     ];
 
     options.include = parseIncludes(params.includes);
+    options.require = (parseString(params.require) === 'true')
     options.attributes = parseString(params.fields);
     options.limit = parseInteger(params.limit);
     options.offset = parseInteger(params.offset);

--- a/src/parser.js
+++ b/src/parser.js
@@ -69,6 +69,7 @@ function parseIncludes(includes) {
             basePtr[includeArr[j]] = {index: returnPtr.length - 1};
           }
           basePtr = basePtr[includeArr[j]];
+          console.log(basePtr[includeArr[j]].index);
           returnPtr = returnPtr.include[basePtr[includeArr[j]].index].include;
         }
       }

--- a/src/parser.js
+++ b/src/parser.js
@@ -18,7 +18,7 @@ function parse(params, { rawAttributes }) {
         'sort'
     ];
     options.include = parseIncludes(params.includes);
-    options.require = (parseString(params.require).toLowerCase() !== 'false')
+    options.require = (!params.require || parseString(params.require).toLowerCase() === 'true');
     options.attributes = parseString(params.fields);
     options.limit = parseInteger(params.limit);
     options.offset = parseInteger(params.offset);

--- a/src/parser.js
+++ b/src/parser.js
@@ -17,9 +17,8 @@ function parse(params, { rawAttributes }) {
         'offset',
         'sort'
     ];
-
     options.include = parseIncludes(params.includes);
-    options.require = (parseString(params.require) === 'true')
+    options.require = (parseString(params.require).toLowerCase() !== 'false')
     options.attributes = parseString(params.fields);
     options.limit = parseInteger(params.limit);
     options.offset = parseInteger(params.offset);

--- a/src/parser.js
+++ b/src/parser.js
@@ -27,9 +27,7 @@ function parse(params, { rawAttributes }) {
     _(params)
         .omit(keywords)
         .forOwn((value, key) => {
-            if (rawAttributes.hasOwnProperty(key)) {
-                options.where[key] = parseJson(value);
-            }
+            options.where[key] = parseJson(value);
         });
 
     return options;

--- a/src/parser.js
+++ b/src/parser.js
@@ -48,19 +48,20 @@ function parseString(value) {
 
 function parseIncludes(includes) {
     if (includes) {
-        includes = includes.split(',');
-        for(let i in includes){
+        includesArr = includes.split(',');
+        includes = {};
+        for(let i in includesArr){
           if(includes[i].indexOf('.') === - 1){
-            continue;
+            includes[includesArr[i]] = {}
           }
           includeArr = includes[i].split('.')
-          let includeObj = {};
-          let includePtr = includeObj;
+          let includePtr = includes;
           for(let j in includeArr){
-            includePtr[includeArr[j]] = {};
+            if(includePtr[includeArr[j]].indexOf('.') === - 1){
+              includePtr[includeArr[j]] = {};
+            }
             includePtr = includePtr[includeArr[j]];
           }
-          includes[i] = includeObj;
         }
     }
     console.log(includes);

--- a/src/parser.js
+++ b/src/parser.js
@@ -55,7 +55,7 @@ function parseIncludes(includes) {
       for(let i in includesArr){
         if(includesArr[i].indexOf('.') === - 1){
           if(!baseObj.hasOwnProperty(includesArr[i])){
-            returnObj.push({model:includesArr[i], include:[]});
+            returnObj.push({association:includesArr[i], include:[]});
             baseObj[includesArr[i]] = {index: returnObj.length - 1};
           }
           continue;
@@ -65,7 +65,7 @@ function parseIncludes(includes) {
         let returnPtr = returnObj;
         for(let j in includeArr){
           if(!basePtr.hasOwnProperty(includeArr[j])){
-            returnPtr.push({model:includeArr[j], include:[]});
+            returnPtr.push({association:includeArr[j], include:[]});
             basePtr[includeArr[j]] = {index: returnPtr.length - 1};
           }
           basePtr = basePtr[includeArr[j]];

--- a/src/parser.js
+++ b/src/parser.js
@@ -47,25 +47,29 @@ function parseString(value) {
 }
 
 function parseIncludes(includes) {
+    let returnObj;
     if (includes) {
-        includesArr = includes.split(',');
-        includes = {};
-        for(let i in includesArr){
-          if(includes[i].indexOf('.') === - 1){
-            includes[includesArr[i]] = {}
+      returnObj = {};
+      let includesArr = includes.split(',');
+      for(let i in includesArr){
+        if(includesArr[i].indexOf('.') === - 1){
+          if(!includes.hasOwnProperty(includesArr[i])){
+            returnObj[includesArr[i]] = {};
           }
-          includeArr = includes[i].split('.')
-          let includePtr = includes;
-          for(let j in includeArr){
-            if(includePtr[includeArr[j]].indexOf('.') === - 1){
-              includePtr[includeArr[j]] = {};
-            }
-            includePtr = includePtr[includeArr[j]];
-          }
+          continue;
         }
+        includeArr = includesArr[i].split('.')
+        let includePtr = returnObj;
+        for(let j in includeArr){
+          if(!includePtr.hasOwnProperty(includeArr[j])){
+            includePtr[includeArr[j]] = {};
+          }
+          includePtr = includePtr[includeArr[j]];
+        }
+      }
     }
-    console.log(includes);
-    return includes;
+    console.log(returnObj);
+    return returnObj;
 }
 
 function parseJson(value) {

--- a/src/parser.js
+++ b/src/parser.js
@@ -68,9 +68,8 @@ function parseIncludes(includes) {
             returnPtr.push({model:includeArr[j], include:[]});
             basePtr[includeArr[j]] = {index: returnPtr.length - 1};
           }
-          basePtr = basePtr[includeArr[j]];
-          console.log(basePtr[includeArr[j]].index);
           returnPtr = returnPtr.include[basePtr[includeArr[j]].index].include;
+          basePtr = basePtr[includeArr[j]];
         }
       }
     }

--- a/src/parser.js
+++ b/src/parser.js
@@ -27,7 +27,7 @@ function parse(params, { rawAttributes }) {
     _(params)
         .omit(keywords)
         .forOwn((value, key) => {
-            if(key.indexOf('.')){
+            if(key.indexOf('.') !== -1){
               key = '$' + key + '$';
               options.where[key] = parseJson(value);
             }else if(rawAttributes.hasOwnProperty(key)){
@@ -50,7 +50,7 @@ function parseIncludes(includes) {
     if (includes) {
         includes = includes.split(',');
         for(let i in includes){
-          if(!includes[i].indexOf('.')){
+          if(includes[i].indexOf('.') === - 1){
             continue;
           }
           includeArr = includes[i].split('.')

--- a/src/parser.js
+++ b/src/parser.js
@@ -18,7 +18,7 @@ function parse(params, { rawAttributes }) {
         'sort'
     ];
 
-    options.include = parseString(params.includes);
+    options.include = parseIncludes(params.includes);
     options.attributes = parseString(params.fields);
     options.limit = parseInteger(params.limit);
     options.offset = parseInteger(params.offset);
@@ -29,8 +29,10 @@ function parse(params, { rawAttributes }) {
         .forOwn((value, key) => {
             if(key.indexOf('.')){
               key = '$' + key + '$';
+              options.where[key] = parseJson(value);
+            }else if(rawAttributes.hasOwnProperty(key)){
+              options.where[key] = parseJson(value);
             }
-            options.where[key] = parseJson(value);
         });
 
     return options;
@@ -42,6 +44,26 @@ function parseString(value) {
     }
 
     return value;
+}
+
+function parseIncludes(includes) {
+    if (includes) {
+        includes = includes.split(',');
+        for(let i in includes){
+          if(includes[i].indexOf('.')){
+            includeArr = includes[i].split('.')
+            let includeObj = {};
+            let includePtr = includeObj;
+            for(let j in includeArr){
+              includePtr[includeArr[j]] = {};
+              includePtr = includePtr[includeArr[j]];
+            }
+            includes[i] = includeObj;
+          }
+        }
+    }
+
+    return includes;
 }
 
 function parseJson(value) {


### PR DESCRIPTION
This pull request allows the user to join across sequelize associations and filter on associated properties.  For example if you have a Asset Table that has a one to many association with a Model table and that table has a one to many association with a Oem table the user could run a query like this: /assets?includes=Model,Model.Oem&Model.Oem.name=cisco